### PR TITLE
configure dynamic version based on latest git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
 ]
-version = "0.1"
 readme = { file = "./README.md", content-type = "text/markdown" }
 dependencies = [
     "Click ~= 8.1",
@@ -17,6 +16,7 @@ dependencies = [
     "jsonschema ~= 4.17"
 ]
 requires-python = ">=3.8.10"
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["black", "autoflake", "isort"]
@@ -35,10 +35,14 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 [tool.setuptools.package-data]
 nl_service_metadata_generator = ["*.json", "*.xml", "*.xsd"]
 
+[tool.setuptools-git-versioning]
+enabled = true
+
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
     "setuptools>=45", 
+    "setuptools-git-versioning==1.13.1",
     "twine==4.0.1",
     "wheel==0.38.4"
 ]


### PR DESCRIPTION
# Omschrijving

automatically configure dynamic version based on latest git tag, with https://setuptools-git-versioning.readthedocs.io/en/stable/index.html