### PR TITLE
add support for generating service md for OAS services

### DIFF
--- a/src/nl_service_metadata_generator/data/json/codelists.json
+++ b/src/nl_service_metadata_generator/data/json/codelists.json
@@ -133,6 +133,16 @@
       "spatial_dataservice_category_label": "Dienst kaarttoegang",
       "service_access_point_operation": "HTTPGet"
     },
+    "oas": {
+      "service_protocol_url": "https://github.com/OAI/OpenAPI-Specification/",
+      "service_protocol": "OAS",
+      "protocol_release_date": "2017-07-26",
+      "service_protocol_name": "Open API Specification",
+      "spatial_dataservice_category": "infoFeatureAccessService",
+      "spatial_dataservice_category_uri": "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoFeatureAccessService",
+      "spatial_dataservice_category_label": "Dienst objecttoegang",
+      "service_access_point_operation": "HTTPGet"
+    },
     "sos": {
       "service_protocol_url": "http://www.opengis.net/def/serviceType/ogc/sos",
       "protocol_release_date": "2012-04-20",
@@ -179,7 +189,7 @@
       "inspire_technicalguidance_date": "2013-04-04"
     },
     {
-      "ogc_service_types": ["wfs", "wcs", "sos", "atom", "oaf"],
+      "ogc_service_types": ["wfs", "wcs", "sos", "atom", "oaf", "oas"],
       "inspire_uri": "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download",
       "inspire_servicetype": "download",
       "inspire_technicalguidance": "https://inspire.ec.europa.eu/documents/technical-guidance-implementation-inspire-download-services",

--- a/src/nl_service_metadata_generator/data/json_schema/service.schema.json
+++ b/src/nl_service_metadata_generator/data/json_schema/service.schema.json
@@ -117,6 +117,19 @@
         "required": ["datasetMdIdentifier"]
       }
     },
+    "service_license":{
+      "type": "object",
+      "minItems": 0,
+      "properties":{
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "thumbnails": {
       "type": "array",
       "minItems": 0,
@@ -167,6 +180,11 @@
       "type": "string",
       "format": "uri"
     },
+    "serviceAccessPointOas": {
+      "description": "Resolvable url that points to service access point",
+      "type": "string",
+      "format": "uri"
+    },
     "serviceAccessPointCsw": {
       "description": "Resolvable url that points to service access point",
       "type": "string",
@@ -202,6 +220,10 @@
       "type": "string",
       "format": "uuid"
     },
+    "mdIdentifierOas": {
+      "type": "string",
+      "format": "uuid"
+    },
     "mdIdentifierSos": {
       "type": "string",
       "format": "uuid"
@@ -234,6 +256,7 @@
     { "required": ["serviceAccessPointSos", "mdIdentifierSos"] },
     { "required": ["serviceAccessPointCsw", "mdIdentifierCsw"] },
     { "required": ["serviceAccessPointOaf", "mdIdentifierOaf"] },
-    { "required": ["serviceAccessPointOat", "mdIdentifierOat"] }
+    { "required": ["serviceAccessPointOat", "mdIdentifierOat"] },
+    { "required": ["serviceAccessPointOas", "mdIdentifierOas"] }
   ]
 }

--- a/src/nl_service_metadata_generator/data/templates/partials/resource_constraints.xml
+++ b/src/nl_service_metadata_generator/data/templates/partials/resource_constraints.xml
@@ -16,11 +16,11 @@
         <gmd:accessConstraints>
             <!-- https://docs.geostandaarden.nl/md/mdprofiel-iso19119/#x5-2-12-juridische-toegangsrestricties -->
             <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"/>
-        </gmd:accessConstraints>   
-        {% if service_licentie -%}
+        </gmd:accessConstraints>
+        {% if service_license -%}
         <gmd:otherConstraints>
             <!-- https://docs.geostandaarden.nl/md/mdprofiel-iso19119/#overige-beperkingen -->
-            <gmx:Anchor xlink:href="{{ service_licentie['url'] }}">{{ service_licentie['description'] }}</gmx:Anchor>
+            <gmx:Anchor xlink:href="{{ service_license['url'] }}">{{ service_license['description'] }}</gmx:Anchor>
         </gmd:otherConstraints>
         {% else %}
         <gmd:otherConstraints>

--- a/src/nl_service_metadata_generator/enums.py
+++ b/src/nl_service_metadata_generator/enums.py
@@ -22,6 +22,7 @@ class ServiceType(str, enum.Enum):
     TMS = "tms"
     OAF = "oaf"
     OAT = "oat"
+    OAS = "oas"
 
 
 class InspireType(str, enum.Enum):

--- a/src/nl_service_metadata_generator/metadata_generator.py
+++ b/src/nl_service_metadata_generator/metadata_generator.py
@@ -25,7 +25,7 @@ from .util import (
 
 def add_dynamic_fields(data_json, ogc_service_type, is_sds_interoperable):
     md_date_stamp = datetime.today().strftime("%Y-%m-%d")
-        
+
     data_json["md_date_stamp"] = md_date_stamp
 
     if (
@@ -64,7 +64,7 @@ def add_dynamic_fields(data_json, ogc_service_type, is_sds_interoperable):
     data_json["service_title"] = service_title
 
     service_abstract = replace_servicetype_var(data_json, ogc_service_type, "service_abstract")
-    data_json["service_abstract"] = service_abstract    
+    data_json["service_abstract"] = service_abstract
 
     service_md_identifier = get_service_md_identifier(data_json, ogc_service_type)
     data_json["md_identifier"] = service_md_identifier
@@ -89,8 +89,9 @@ def add_dynamic_fields(data_json, ogc_service_type, is_sds_interoperable):
         data_json["sds_category_uri"] = sds_values["uri"]
         data_json["sds_category"] = str(data_json["sds_category"].value)
 
-    inspire_themes = [{"uri": uri, "label": get_inspire_theme_label(uri)} for uri in data_json["inspire_theme_uris"]]
-    data_json["inspire_themes"] = inspire_themes
+    if "inspire_theme_uris" in data_json:
+        inspire_themes = [{"uri": uri, "label": get_inspire_theme_label(uri)} for uri in data_json["inspire_theme_uris"]]
+        data_json["inspire_themes"] = inspire_themes
     return data_json
 
 


### PR DESCRIPTION
Add support for generating service md for OAS services. 

So we can already generate service md for ogc api protocols that have not been added to the dutch nl metadata profile. 